### PR TITLE
Refactor parse_by_symbol/1 function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: elixir
 elixir:
   - 1.1.1
+  - 1.2.2
 otp_release:
   - 18.0
 after_script:

--- a/lib/currency.ex
+++ b/lib/currency.ex
@@ -75,10 +75,7 @@ defmodule Monetized.Currency do
   """
 
   def parse_by_symbol(str) do
-    x =
-      all
-      |> Enum.map(fn {k, v} -> {v.symbol, k} end)
-      |> Enum.into(%{})
+    x = Enum.map(all, fn {k, v} -> {v.symbol, k} end) |> Enum.into(%{})
     case Regex.run(~r/\p{Sc}/u, str) do
       [s] ->
         get(x[s])

--- a/lib/currency.ex
+++ b/lib/currency.ex
@@ -75,7 +75,10 @@ defmodule Monetized.Currency do
   """
 
   def parse_by_symbol(str) do
-    x = Enum.map(all, fn {k, v} -> {v.symbol, k} end)
+    x =
+      all
+      |> Enum.map(fn {k, v} -> {v.symbol, k} end)
+      |> Enum.into(%{})
     case Regex.run(~r/\p{Sc}/u, str) do
       [s] ->
         get(x[s])


### PR DESCRIPTION
Refactor `parse_by_symbol/1` function in order to prevent an error as below when using Elixir 1.2.2
`Doctest failed: got ArgumentError with message the Access calls for keywords expect the key to be an atom, got: "$"`
