### PR TITLE
Add Poison Decode implementation for Money

### DIFF
--- a/lib/poison.ex
+++ b/lib/poison.ex
@@ -1,0 +1,7 @@
+if Code.ensure_loaded?(Poison) do
+  defimpl Poison.Decoder, for: Monetized.Money do
+    def decode(%{currency: currency, value: value}, _options) do
+      Monetized.Money.make(value, currency: currency)
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,8 @@ defmodule Monetized.Mixfile do
       {:earmark, "~> 0.2.1",  only: :dev},
       {:inch_ex, "~> 0.5.1",  only: :docs},
       {:decimal, "~> 1.1.2"},
-      {:ecto,    "~> 1.1.7"}
+      {:ecto,    "~> 1.1.7"},
+      {:poison, "~> 1.5 or ~> 2.0", optional: true},
     ]
   end
 

--- a/test/poison_test.exs
+++ b/test/poison_test.exs
@@ -1,0 +1,10 @@
+defmodule PoisonTest do
+  use ExUnit.Case, async: true
+  alias Monetized.Money
+
+  test "Poison serialization" do
+    money = Money.make("$100.50")
+
+    assert money |> Poison.encode! |> Poison.decode!(as: %Money{}) == money
+  end
+end


### PR DESCRIPTION
Ecto implements Encode for Decimal, which turns it to a string. We cant use `Money.dump()` because Poison will only call a struct specific implementation for json objects which get inflated to `Map()`
