### PR TITLE
Prevent regex error converting Money without a decimal to string

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -146,6 +146,9 @@ defmodule Monetized.Money do
       ...> Monetized.Money.to_string(money, [currency_code: true])
       "100.50 EUR"
 
+      iex> money = Monetized.Money.make(Decimal.new("10"))
+      ...> Monetized.Money.to_string(money)
+      "10.00"
   """
 
   @spec to_string(money, list) :: String.t
@@ -154,7 +157,9 @@ defmodule Monetized.Money do
     delimiter = option_or_config(config, options, :delimiter)
     separator = option_or_config(config, options, :separator)
 
-    [base, decimal] = Regex.split(~r/\./, Decimal.to_string(money.value))
+    value_as_string = Decimal.to_string(money.value)
+    value = if String.contains?(value_as_string, "."), do: value_as_string, else: value_as_string <> ".00"
+    [base, decimal] = Regex.split(~r/\./, value)
 
     number = String.to_integer(base)
     |> delimit_integer(delimiter)


### PR DESCRIPTION
# Why

Creating a Money struct from an integer will cause a regex error if you call Money.to_string/1

```
iex> Monetized.Money.to_string(Monetized.Money.make(Decimal.new("10")))
** (MatchError) no match of right hand side value: ["10"]
```

Expected either "10" or "10.00" - I went with "10.00" because it seemed simpler.

```
iex> money = Monetized.Money.make(Decimal.new("10"))
...> Monetized.Money.to_string(money)
"10.00"
```
