### PR TITLE
Add deps badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Monetized
 [![Build Status](https://travis-ci.org/theocodes/monetized.svg?branch=master)](https://travis-ci.org/theocodes/monetized)
+[![Deps Status](https://beta.hexfaktor.org/badge/all/github/theocodes/monetized.svg)](https://beta.hexfaktor.org/github/theocodes/monetized)
 [![Inline docs](http://inch-ci.org/github/theocodes/monetized.svg)](http://inch-ci.org/github/theocodes/monetized)
 
 As a general rule, using floats to store money is a [bad idea](http://spin.atomicobject.com/2014/08/14/currency-rounding-errors/).


### PR DESCRIPTION
Hi there,

I'm the maintainer of [Inch CI](https://inch-ci.org/) and this PR pitches my latest project for the Elixir community.

Here comes the pitch:

[![Deps Status](https://beta.hexfaktor.org/badge/all/github/theocodes/monetized.svg)](https://beta.hexfaktor.org/github/theocodes/monetized) [![Inline docs](http://inch-ci.org/github/theocodes/monetized.svg?branch=master)](http://inch-ci.org/github/theocodes/monetized)

You already know the Inch badge on the right: It shows you an analysis for your Elixir project's docs. The new badge does the same thing for your dependencies.

Behind the badge works a CI service written in Elixir which can notify you whenever important updates for your Hex packages are released.

This is still in its infancy, and I want to basically invite you to join the beta to test-drive this. I really believe that we can create a great service for the community with this. That said, don't feel any obligation to accept the PR. You can't hurt my feelings by voicing your honest opinion about this idea!
