### PR TITLE
Add benchmarks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ erl_crash.dump
 *#
 #*
 *~
+/bench/snapshots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+###Improve Money.make performance for:
+  * `from_integer`
+  * `from_decimal`
+  * `from_float`
+  * `zero`

--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ end
 - [ ] Add more currencies (PRs are welcome)
 - [ ] Get feedback...
 
+## Benchmarking
+
+```sh-session
+$ mix deps.get
+$ MIX_ENV=bench mix compile
+$ MIX_ENV=bench mix bench
+```
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for details.

--- a/bench/currency_bench.exs
+++ b/bench/currency_bench.exs
@@ -1,0 +1,23 @@
+defmodule CurrencyBench do
+  use Benchfella
+
+  bench "parse" do
+    Monetized.Currency.parse("EUR 200.00")
+  end
+
+  bench "parse_by_key" do
+    Monetized.Currency.parse("EUR 200.00")
+  end
+
+  bench "parse_by_symbol" do
+    Monetized.Currency.parse_by_symbol("€ 200.00")
+  end
+
+  bench "all" do
+    Monetized.Currency.all
+  end
+
+  bench "get" do
+    Monetized.Currency.get("EUR")
+  end
+end

--- a/bench/money_bench.exs
+++ b/bench/money_bench.exs
@@ -1,0 +1,32 @@
+defmodule MoneyBench do
+  use Benchfella
+
+  bench "make with string" do
+    Monetized.Money.make("$100")
+  end
+
+  bench "make with string and currency option" do
+    Monetized.Money.make("100", currency: "USD")
+  end
+
+  bench "make with float" do
+    Monetized.Money.make(100.00, currency: "USD")
+  end
+
+  bench "make with integer" do
+    Monetized.Money.make(100, currency: "USD")
+  end
+
+  bench "make with formatted decimal", decimal: Decimal.new("100.00") do
+    Monetized.Money.make(decimal, currency: "USD")
+  end
+
+  # decimal doesnt have exp -2, meaning the decimal has to be coerced
+  bench "make with unformatted decimal", decimal: Decimal.new(100.00) do
+    Monetized.Money.make(decimal, currency: "USD")
+  end
+
+  bench "zero" do
+    Monetized.Money.zero(currency: "USD")
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,7 @@ defmodule Monetized.Mixfile do
       {:inch_ex, "~> 0.5.1",  only: :docs},
       {:decimal, "~> 1.1.2"},
       {:ecto,    "~> 1.1.7"},
-      {:benchfella, "~> 0.3.2", only: :dev},
+      {:benchfella, "~> 0.3.2", only: :bench},
     ]
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,8 @@ defmodule Monetized.Mixfile do
       {:earmark, "~> 0.2.1",  only: :dev},
       {:inch_ex, "~> 0.5.1",  only: :docs},
       {:decimal, "~> 1.1.2"},
-      {:ecto,    "~> 1.1.7"}
+      {:ecto,    "~> 1.1.7"},
+      {:benchfella, "~> 0.3.2", only: :dev},
     ]
   end
 


### PR DESCRIPTION
Improve performance of `from_decimal`, `from_integer`, `from_float`. These are microbenchmarks so to be taken w/ a grain of salt, but I think you can see that in the implementation that circumventing doing the `to_string` dance would improve performance

before

```
make with formatted decimal               100000   12.78 µs/op
make with unformatted decimal             100000   17.89 µs/op
make with string                           50000   35.91 µs/op
make with string and currency option       50000   41.40 µs/op
make with integer                          50000   42.34 µs/op
zero                                       50000   42.46 µs/op
make with float                            50000   42.55 µs/op
```

After

```
zero                                     1000000   1.16 µs/op
make with formatted decimal              1000000   1.23 µs/op
make with integer                        1000000   1.38 µs/op
make with float                           500000   4.62 µs/op
make with unformatted decimal             100000   18.11 µs/op
make with string                          100000   23.50 µs/op
make with string and currency option       50000   32.78 µs/op
```
