### PR TITLE
Prevent error when a `Decimal` does not have a decimal and introduce rounding in `Money.to_string`

### DIFF
--- a/lib/money.ex
+++ b/lib/money.ex
@@ -189,7 +189,7 @@ defmodule Monetized.Money do
     |> String.strip
   end
 
-  def decimal_parts(str, decimal_places) do
+  defp decimal_parts(str, decimal_places) do
     case String.split(str, ".") do
       [int]          -> {int, IO.iodata_to_binary(:lists.duplicate(decimal_places, ?0))}
       [int, decimal] -> {int, String.ljust(decimal, decimal_places, ?0)}

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,7 @@ defmodule Monetized.Mixfile do
       {:earmark, "~> 0.2.1",  only: :dev},
       {:inch_ex, "~> 0.5.1",  only: :docs},
       {:decimal, "~> 1.1.2"},
-      {:ecto,    "~> 1.1.7"}
+      {:ecto,    "~> 2.0.4"}
     ]
   end
 


### PR DESCRIPTION
This is a different take on: PR #14 -- We work together and I didn't realize he had opened a PR.  In addition to fixing the issue with the potential lack of a decimal place, this also rounds the money to a configurable number of `decimal_places`:

```
iex> money = Monetized.Money.make(Decimal.new(".005"), currency: "USD")
...> Monetized.Money.to_string(money, currency_symbol: true)
"$ 0.01"
```
