### PR TITLE
Update Mix file for new versions of ecto/poison

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,7 +6,7 @@ defmodule Monetized.Mixfile do
      name: "Monetized",
      source_url: "https://github.com/theocodes/monetized",
      version: "0.5.1",
-     elixir: "~> 1.3",
+     elixir: ">= 1.3.0",
      description: description(),
      package: package(),
      build_embedded: Mix.env == :prod,
@@ -22,11 +22,11 @@ defmodule Monetized.Mixfile do
     [
       {:ex_doc,  "~> 0.11.5", only: :dev},
       {:earmark, "~> 0.2.1",  only: :dev},
-      {:inch_ex, "~> 0.5.1",  only: :docs},
-      {:decimal, "~> 1.3"},
-      {:ecto,    "~> 2.1.3"},
+      {:inch_ex, "~> 2.0.0",  only: :docs},
+      {:decimal, "~> 1.8.1"},
+      {:ecto,    ">= 2.1.0"},
       {:benchfella, "~> 0.3.2", only: :bench},
-      {:poison, "~> 1.5 or ~> 2.0", optional: true},
+      {:poison, ">= 1.5.0", optional: true},
     ]
   end
 


### PR DESCRIPTION
Update the Mix file to use more updated dependencies for poison and ecto to accommodate more modern version of them, my current project would love to use `monetized` but we use `poison` at `3.1.0` and `ecto` at `3.4.6`.  Looking at the changes implemented for the major version upgrades, I see no reason why `monetized` can't upgrade their dependencies to keep up with the current standard.